### PR TITLE
feat: implement Firebase storage for /rpg-register command

### DIFF
--- a/lib/user-service.js
+++ b/lib/user-service.js
@@ -54,6 +54,45 @@ export async function awardXP(userEmail, xpAmount, reason) {
   };
 }
 
+// Helper function to create a new user
+export async function createUser(slackUserId, userName, email) {
+  // Check if user already exists by Slack ID
+  const existingUserBySlack = await getUserBySlackId(slackUserId);
+  if (existingUserBySlack) {
+    throw new Error('User already registered with this Slack account');
+  }
+  
+  // Check if user already exists by email
+  const userRef = doc(db, 'users', email);
+  const userSnap = await getDoc(userRef);
+  if (userSnap.exists()) {
+    throw new Error('User already registered with this email');
+  }
+  
+  // Create new user document
+  const newUserData = {
+    slackUserId: slackUserId,
+    jiraUsername: email,
+    displayName: userName,
+    xp: 0,
+    level: 1,
+    currentTitle: getTitleForLevel(1),
+    guilds: [],
+    achievements: [],
+    totalTickets: 0,
+    totalBugs: 0,
+    createdAt: new Date(),
+    lastActivity: new Date()
+  };
+  
+  await setDoc(userRef, newUserData);
+  
+  return {
+    email: email,
+    ...newUserData
+  };
+}
+
 // Helper function to award XP from JIRA webhook payload
 export async function awardXpFromWebhook(userEmail, webhookPayload) {
   const xpAward = calculateXpAward(webhookPayload);


### PR DESCRIPTION
- Add createUser() function with duplicate user validation
- Replace TODO in handleRegisterCommand with full Firebase integration
- Include proper error handling for registration edge cases
- Users can now manually link Slack accounts to JIRA emails

🤖 Generated with [Claude Code](https://claude.ai/code)