### PR TITLE
Feature: Replace guild creation with Slack modal form

### DIFF
--- a/slack-commands.md
+++ b/slack-commands.md
@@ -17,7 +17,9 @@ Make sure your bot has these OAuth scopes:
 - `conversations.info` - Get channel details
 - `conversations.members` - Check channel membership
 - `users:read` - Read user information
-- `views:open` - Open modals (required for guild creation form)
+- `commands` - Handle slash commands (likely already configured)
+
+**Note:** Slack modals use the existing bot token permissions. No additional scopes are needed for the `views.open` API call - it uses your bot's existing `chat:write` capabilities.
 
 ---
 

--- a/slack-commands.md
+++ b/slack-commands.md
@@ -17,6 +17,7 @@ Make sure your bot has these OAuth scopes:
 - `conversations.info` - Get channel details
 - `conversations.members` - Check channel membership
 - `users:read` - Read user information
+- `views:open` - Open modals (required for guild creation form)
 
 ---
 
@@ -72,9 +73,9 @@ Make sure your bot has these OAuth scopes:
 ### /rpg-guild-create
 **Command:** `/rpg-guild-create`  
 **Request URL:** `https://your-domain.vercel.app/api/slack-commands`  
-**Short Description:** Create a new guild with JIRA mapping  
-**Usage Hint:** `/rpg-guild-create #dev-frontend "Frontend Warriors" UI,React frontend,ui-bug`  
-**Escape channels, users, and links sent to your app:** ☐ Unchecked (need raw channel IDs)
+**Short Description:** Create a new guild with JIRA mapping (opens form)  
+**Usage Hint:** `/rpg-guild-create`  
+**Escape channels, users, and links sent to your app:** ☑️ Checked
 
 ---
 
@@ -197,10 +198,14 @@ Replace `https://your-domain.vercel.app` with your actual Vercel deployment URL.
 
 ### Escape Settings
 - **Checked (☑️):** For commands that work with escaped mentions like `<@U123456|username>`
-- **Unchecked (☐):** For commands that need raw IDs like `/rpg-guild-create` and `/rpg-guild-kick`
+- **Unchecked (☐):** For commands that need raw IDs like `/rpg-guild-kick` and `/rpg-guild-transfer`
 
-### Guild Creation Special Note
-The `/rpg-guild-create` command needs raw channel IDs to validate channels properly. When users type `#dev-frontend`, Slack sends `<#C123456|dev-frontend>` which our parser extracts the channel ID from.
+### Guild Creation Modal
+The `/rpg-guild-create` command opens a user-friendly modal form where users can:
+- Select a channel from a dropdown
+- Enter guild name, components, and labels in separate fields
+- Get validation feedback before creation
+- Specify components OR labels OR both (at least one required)
 
 ## Environment Variables Required
 
@@ -223,7 +228,7 @@ After configuring, test each command in this order:
 1. `/rpg-help` - Verify basic connectivity
 2. `/rpg-register your.email@company.com` - Create user account
 3. `/rpg-status` - Check user data
-4. `/rpg-guild-create #test-channel "Test Guild" TestComponent test-label` - Create guild
+4. `/rpg-guild-create` - Create guild (opens form)
 5. `/rpg-guild-list` - Verify guild creation
 6. `/rpg-guild-join "Test Guild"` - Test joining
 7. `/rpg-guild-info "Test Guild"` - Check guild details


### PR DESCRIPTION
## Summary
Replaces the complex argument parsing for guild creation with a user-friendly Slack modal form.

## Problem Solved
The original  command required complex argument parsing that made it difficult to:
- Distinguish between components and labels  
- Handle optional vs required fields
- Provide clear validation feedback
- Support flexible input combinations (components only, labels only, or both)

## Solution: Slack Modal Form
### New User Experience
1. User runs  (no arguments)
2. Modal form opens with clear labeled fields
3. User selects channel from dropdown
4. User enters guild name, components, labels as needed
5. Form validates and creates guild with feedback

### Modal Features
- 📋 **Channel Selector**: Dropdown with all available channels
- 🏰 **Guild Name**: Text input with placeholder examples  
- 🎯 **Components**: Optional comma-separated JIRA components
- 🏷️ **Labels**: Optional comma-separated JIRA labels
- ✅ **Validation**: At least one component or label required
- 💡 **Help Text**: Built-in guidance and examples

## Technical Implementation
- **Interactive Components**: Modal submission handler
- **Channel Validation**: Bot membership and access checks
- **Error Handling**: Field-specific validation messages
- **Static Imports**: No dynamic import issues
- **OAuth Scope**: Added `views:open` permission requirement

## Files Modified
- **api/slack-commands.js** - Added modal handlers and interactive components
- **slack-commands.md** - Updated configuration and documentation

## Benefits
- ✅ **Better UX**: Intuitive form vs complex command syntax
- ✅ **Flexible Input**: Components OR labels OR both
- ✅ **Clear Validation**: Field-specific error messages  
- ✅ **Channel Safety**: Built-in channel validation
- ✅ **Scalable**: Easy to add more fields in future

## Testing
Requires updating Slack app configuration:
- Add `views:open` OAuth scope
- Test modal opening and submission flow
- Verify channel validation and guild creation

🤖 Generated with [Claude Code](https://claude.ai/code)