### PR TITLE
Fix Slack API calls: remove body from GET requests

### DIFF
--- a/lib/slack-service.js
+++ b/lib/slack-service.js
@@ -273,15 +273,14 @@ function formatTeamStoryMessage(storyData, ticketInfo, userInfo) {
  */
 export async function validateSlackChannel(channelId) {
   try {
-    const response = await fetch('https://slack.com/api/conversations.info', {
+    const url = new URL('https://slack.com/api/conversations.info');
+    url.searchParams.append('channel', channelId);
+    
+    const response = await fetch(url, {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      body: new URLSearchParams({
-        channel: channelId
-      })
+        'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`
+      }
     });
 
     const result = await response.json();
@@ -326,15 +325,14 @@ export async function validateSlackChannel(channelId) {
  */
 async function checkBotMembership(channelId) {
   try {
-    const response = await fetch('https://slack.com/api/conversations.members', {
+    const url = new URL('https://slack.com/api/conversations.members');
+    url.searchParams.append('channel', channelId);
+    
+    const response = await fetch(url, {
       method: 'GET',
       headers: {
-        'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`,
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      body: new URLSearchParams({
-        channel: channelId
-      })
+        'Authorization': `Bearer ${process.env.SLACK_BOT_TOKEN}`
+      }
     });
 
     const result = await response.json();


### PR DESCRIPTION
Fix TypeError in channel validation by moving query parameters from request body to URL query string for GET requests:

- conversations.info API call
- conversations.members API call

GET requests cannot have a body, parameters must be in URL.

🤖 Generated with [Claude Code](https://claude.ai/code)