### PR TITLE
Fix: Improve /rpg-status display with guild names and Slack usernames

### DIFF
--- a/api/slack-commands.js
+++ b/api/slack-commands.js
@@ -11,6 +11,7 @@ import {
   leaveGuild,
   getAllActiveGuilds,
   getGuildByName,
+  getGuildById,
   getGuildsByUser,
   renameGuild,
   kickGuildMember,
@@ -235,12 +236,26 @@ Once registered, you'll start earning XP and leveling up! 🗡️`,
     const userData = querySnapshot.docs[0].data();
     const progressToNext = calculateProgressToNextLevel(userData.xp, userData.level);
     
-    const statusText = `🏆 **${userData.displayName}** *(${userData.currentTitle})*
+    // Resolve guild IDs to guild names
+    let guildNames = 'None';
+    if (userData.guilds && userData.guilds.length > 0) {
+      const guildNamePromises = userData.guilds.map(async (guildId) => {
+        const guild = await getGuildById(guildId);
+        return guild ? guild.name : `Unknown Guild (${guildId})`;
+      });
+      const resolvedGuildNames = await Promise.all(guildNamePromises);
+      guildNames = resolvedGuildNames.join(', ');
+    }
+    
+    const statusText = `🏆 **${userName}** *(${userData.currentTitle})*
 
 📊 **Level ${userData.level}** | **${userData.xp} XP**
 📈 Progress to Level ${userData.level + 1}: ${progressToNext.current}/${progressToNext.needed} XP (${progressToNext.percentage}%)
 
-🏰 **Guilds:** ${userData.guilds?.join(', ') || 'None'}
+🏰 **Guilds:** ${guildNames}
+⚔️ **Total Quests:** ${userData.totalTickets || 0}
+🐛 **Bugs Slain:** ${userData.totalBugs || 0}
+🕐 **Last Quest:** ${userData.lastActivity ? new Date(userData.lastActivity.seconds * 1000).toLocaleDateString() : 'Never'}
 
 Keep completing tickets to level up! 🌟`;
 


### PR DESCRIPTION
## Summary
Fixes user experience issues in the  command by displaying readable information instead of internal IDs.

## Issues Fixed

### 1. Guild IDs → Guild Names
**Before:**   
**After:** 

- Resolves each guild ID to actual guild name
- Handles deleted/missing guilds gracefully
- Uses Promise.all for efficient async resolution

### 2. JIRA Username → Slack Display Name  
**Before:**   
**After:** 

- Uses Slack username parameter instead of stored displayName
- Shows the name users recognize from Slack interface

### 3. Enhanced Status Information
Added missing quest statistics:
- ⚔️ Total Quests completed
- 🐛 Bugs Slain count  
- 🕐 Last Quest activity date

## Technical Implementation
- Added  import to resolve guild references
- Implemented async guild name resolution with error handling
- Enhanced status display formatting
- Maintained backward compatibility

## Testing
- ✅ Users with no guilds: Shows 'None'  
- ✅ Users with valid guilds: Shows guild names
- ✅ Users with deleted guilds: Shows 'Unknown Guild (id)'
- ✅ Slack username properly displayed

This provides a much more user-friendly status display that matches user expectations.

🤖 Generated with [Claude Code](https://claude.ai/code)