### PR TITLE
fix: Robust Slack message formatting with text sanitization

### DIFF
--- a/lib/slack-service.js
+++ b/lib/slack-service.js
@@ -135,34 +135,87 @@ async function findUserByJiraUsername(username) {
  * @returns {Object} - Formatted Slack message payload
  */
 function formatStoryMessage(storyData, ticketInfo) {
-  const { narrative } = storyData;
+  const { narrative, storyData: newStoryData, xpAward } = storyData;
   const { issueKey, issueUrl, summary } = ticketInfo;
+  
+  // Extract story data from new or old format
+  const story = newStoryData ? newStoryData : { story: narrative, loot: null, achievements: null };
+  
+  // Sanitize text for Slack (remove/escape problematic characters, limit length)
+  function sanitizeText(text, maxLength = 3000) {
+    if (!text) return '';
+    return String(text).slice(0, maxLength).replace(/[<>&]/g, (match) => {
+      const entities = { '<': '&lt;', '>': '&gt;', '&': '&amp;' };
+      return entities[match] || match;
+    });
+  }
   
   // Create JIRA link (fallback if no URL provided)
   const jiraLink = issueUrl || `https://your-domain.atlassian.net/browse/${issueKey}`;
+  const storyText = sanitizeText(story.story || narrative, 2000);
   
-  // Format message with blocks for better presentation
+  const blocks = [
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: storyText
+      }
+    }
+  ];
+  
+  // Add XP section if present
+  if (xpAward && xpAward.xp > 0) {
+    const xpReason = xpAward.reason ? sanitizeText(xpAward.reason, 200) : '';
+    const xpText = `⚡ *XP Gained:* +${xpAward.xp} XP${xpReason ? ` (${xpReason})` : ''}`;
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: sanitizeText(xpText, 500)
+      }
+    });
+  }
+  
+  // Add loot section if present
+  if (story.loot) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `🎁 *Loot Acquired:* ${sanitizeText(story.loot, 300)}`
+      }
+    });
+  }
+  
+  // Add achievement section if present
+  if (story.achievements) {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `🏆 *Achievement Unlocked:* ${sanitizeText(story.achievements, 300)}`
+      }
+    });
+  }
+  
+  // Add divider and JIRA link
+  blocks.push(
+    {
+      type: 'divider'
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `📋 *JIRA Ticket:* <${jiraLink}|${issueKey}>`
+      }
+    }
+  );
+  
   return {
     text: `New quest story for ${issueKey}`,
-    blocks: [
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: narrative
-        }
-      },
-      {
-        type: 'divider'
-      },
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `📋 *JIRA Ticket:* <${jiraLink}|${issueKey}>`
-        }
-      }
-    ]
+    blocks
   };
 }
 
@@ -238,32 +291,46 @@ function formatTeamStoryMessage(storyData, ticketInfo, userInfo) {
   // Extract story data from new or old format
   const story = newStoryData ? newStoryData : { story: narrative, loot: null, achievements: null };
   
+  // Sanitize text for Slack (remove/escape problematic characters, limit length)
+  function sanitizeText(text, maxLength = 3000) {
+    if (!text) return '';
+    return String(text).slice(0, maxLength).replace(/[<>&]/g, (match) => {
+      const entities = { '<': '&lt;', '>': '&gt;', '&': '&amp;' };
+      return entities[match] || match;
+    });
+  }
+  
   const jiraLink = issueUrl || `https://your-domain.atlassian.net/browse/${issueKey}`;
+  const guildName = sanitizeText(guildInfo?.guildName || 'Guild', 100);
+  const storyText = sanitizeText(story.story || narrative, 2000);
+  const heroName = sanitizeText(displayName || 'Unknown Hero', 100);
   
   const blocks = [
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `🏰 *${guildInfo?.guildName || 'Guild'} Quest Update*`
+        text: `🏰 *${guildName} Quest Update*`
       }
     },
     {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: story.story || narrative
+        text: storyText
       }
     }
   ];
   
   // Add XP section if present
   if (xpAward && xpAward.xp > 0) {
+    const xpReason = xpAward.reason ? sanitizeText(xpAward.reason, 200) : '';
+    const xpText = `⚡ *XP Gained:* +${xpAward.xp} XP${xpReason ? ` (${xpReason})` : ''}`;
     blocks.push({
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `⚡ *XP Gained:* +${xpAward.xp} XP${xpAward.reason ? ` (${xpAward.reason})` : ''}`
+        text: sanitizeText(xpText, 500)
       }
     });
   }
@@ -274,7 +341,7 @@ function formatTeamStoryMessage(storyData, ticketInfo, userInfo) {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `🎁 *Loot Acquired:* ${story.loot}`
+        text: `🎁 *Loot Acquired:* ${sanitizeText(story.loot, 300)}`
       }
     });
   }
@@ -285,7 +352,7 @@ function formatTeamStoryMessage(storyData, ticketInfo, userInfo) {
       type: 'section',
       text: {
         type: 'mrkdwn',
-        text: `🏆 *Achievement Unlocked:* ${story.achievements}`
+        text: `🏆 *Achievement Unlocked:* ${sanitizeText(story.achievements, 300)}`
       }
     });
   }
@@ -296,7 +363,7 @@ function formatTeamStoryMessage(storyData, ticketInfo, userInfo) {
     elements: [
       {
         type: 'mrkdwn',
-        text: `👤 *Hero:* ${displayName} • 📋 *Quest:* <${jiraLink}|${issueKey}>`
+        text: `👤 *Hero:* ${heroName} • 📋 *Quest:* <${jiraLink}|${issueKey}>`
       }
     ]
   });


### PR DESCRIPTION
## Summary
- Fixes `invalid_blocks` error in Slack API by adding robust text sanitization
- Prevents HTML entities and excessive text length from breaking Slack messages
- Updates both individual DM and guild channel notification formats
- Maintains compatibility with enhanced story system (XP, loot, achievements)

## Key Fixes
- **Text Sanitization**: Escape HTML entities (`<`, `>`, `&`) that break Slack blocks
- **Length Limits**: Apply appropriate limits (story: 2000, XP reason: 200, loot/achievements: 300 chars)
- **Null Safety**: Handle `null`/`undefined` values gracefully to prevent "undefined" interpolation
- **Updated Both Functions**: `formatStoryMessage()` and `formatTeamStoryMessage()`

## Root Cause
The `invalid_blocks` error was caused by:
1. Unescaped HTML characters in story text or XP reasons
2. Text content exceeding Slack's API length limits  
3. Undefined values being interpolated as "undefined" strings

## Test plan
- [x] Test Slack message formatting with various story content
- [x] Verify HTML entity escaping works correctly
- [x] Confirm length limits prevent API errors
- [x] Test with both legacy and new story data formats
- [x] Validate XP, loot, and achievement display

🤖 Generated with [Claude Code](https://claude.ai/code)