### PR TITLE
Fix undefined JIRA URL in guild channel messages

### DIFF
--- a/lib/slack-service.js
+++ b/lib/slack-service.js
@@ -161,7 +161,7 @@ function formatStoryMessage(storyData, ticketInfo) {
   }
   
   // Create JIRA link (fallback if no URL provided)
-  const jiraLink = issueUrl || `https://your-domain.atlassian.net/browse/${issueKey}`;
+  const jiraLink = issueUrl || (process.env.JIRA_API_URL ? `${process.env.JIRA_API_URL}/browse/${issueKey}` : `${issueKey}`);
   
   // Get story text with better fallback handling - fix double nesting issue
   console.log('formatStoryMessage - story object:', story);
@@ -345,7 +345,7 @@ function formatTeamStoryMessage(storyData, ticketInfo, userInfo) {
     });
   }
   
-  const jiraLink = issueUrl || `https://your-domain.atlassian.net/browse/${issueKey}`;
+  const jiraLink = issueUrl || (process.env.JIRA_API_URL ? `${process.env.JIRA_API_URL}/browse/${issueKey}` : `${issueKey}`);
   const guildName = sanitizeText(guildInfo?.guildName || 'Guild', 100);
   
   // Get story text with better fallback handling - fix double nesting issue

--- a/lib/story-generator.js
+++ b/lib/story-generator.js
@@ -357,7 +357,7 @@ export async function routeStoryToGuilds(webhookPayload) {
         
         const ticketInfo = {
           issueKey: issue.key,
-          issueUrl: `${webhookPayload.self?.split('/rest/')[0]}/browse/${issue.key}`,
+          issueUrl: webhookPayload.self ? `${webhookPayload.self.split('/rest/')[0]}/browse/${issue.key}` : null,
           summary: issue.fields.summary
         };
         


### PR DESCRIPTION
## Summary
- Fixes guild channel message formatting where JIRA links displayed as `<undefined/browse/ECS-27|ECS-27>`
- Improves error handling for missing webhook `self` property
- Adds proper fallback to `JIRA_API_URL` environment variable

## Changes
- Updated `story-generator.js` to properly check for `webhookPayload.self` before URL construction
- Enhanced `slack-service.js` fallback logic to use `JIRA_API_URL` environment variable
- Graceful degradation to just ticket key when no URL is available

## Test plan
- [x] Verify JIRA URL construction with missing `self` property
- [x] Test fallback logic with environment variable
- [ ] Deploy and verify guild channel messages display proper JIRA links

🤖 Generated with [Claude Code](https://claude.ai/code)