### PR TITLE
feat: Enable quest and bug tracking in /rpg-status command

### DIFF
--- a/lib/user-service.js
+++ b/lib/user-service.js
@@ -111,8 +111,10 @@ export async function validateJiraUsername(username) {
 
 // Note: calculateLevel function now imported from xp-calculator.js
 
-// Helper function to award XP
-export async function awardXP(userEmail, xpAmount, reason) {
+// Helper function to award XP with optional quest/bug tracking
+export async function awardXP(userEmail, xpAmount, reason, options = {}) {
+  const { isTicketCompletion = false, isBugFix = false } = options;
+  
   const userRef = doc(db, 'users', userEmail);
   const userSnap = await getDoc(userRef);
   
@@ -129,18 +131,34 @@ export async function awardXP(userEmail, xpAmount, reason) {
   // Check for level up
   const levelUpInfo = checkLevelUp(oldXp, newXp);
   
-  // Update user data with new XP, level, and title
-  await updateDoc(userRef, {
+  // Build update object with XP and level changes
+  const updates = {
     xp: newXp,
     level: newLevel,
     currentTitle: newTitle,
     lastActivity: new Date()
-  });
+  };
+  
+  // Add counter increments if applicable
+  if (isTicketCompletion) {
+    updates.totalTickets = increment(1);
+  }
+  
+  if (isBugFix) {
+    updates.totalBugs = increment(1);
+  }
+  
+  // Perform atomic update with all changes
+  await updateDoc(userRef, updates);
   
   return {
     xpAwarded: xpAmount,
     reason,
     totalXp: newXp,
+    tracking: {
+      ticketCompleted: isTicketCompletion,
+      bugFixed: isBugFix
+    },
     ...levelUpInfo
   };
 }
@@ -235,7 +253,7 @@ export async function createUserWithEmail(slackUserId, userName, email) {
   };
 }
 
-// Enhanced function to award XP from JIRA webhook with flexible user lookup
+// Enhanced function to award XP from JIRA webhook with flexible user lookup and tracking
 export async function awardXpFromWebhook(userIdentifier, webhookPayload) {
   const xpAward = calculateXpAward(webhookPayload);
   
@@ -243,11 +261,21 @@ export async function awardXpFromWebhook(userIdentifier, webhookPayload) {
     return {
       xpAwarded: 0,
       reason: xpAward.reason,
-      leveledUp: false
+      leveledUp: false,
+      tracking: {
+        ticketCompleted: false,
+        bugFixed: false
+      }
     };
   }
   
-  return await awardXP(userIdentifier, xpAward.xp, xpAward.reason);
+  // Extract tracking information from XP calculation
+  const trackingOptions = {
+    isTicketCompletion: xpAward.tracking?.isTicketCompletion || false,
+    isBugFix: xpAward.tracking?.isBugFix || false
+  };
+  
+  return await awardXP(userIdentifier, xpAward.xp, xpAward.reason, trackingOptions);
 }
 
 // Function to auto-create user from webhook data when not found

--- a/lib/xp-calculator.js
+++ b/lib/xp-calculator.js
@@ -204,9 +204,18 @@ export function calculateXpAward(payload) {
     }
   }
 
+  // Determine tracking flags for quest and bug counting
+  const isTicketCompletion = (toStatus === 'Done' || toStatus === 'Closed' || toStatus === 'Resolved') && 
+                             fromStatus !== toStatus && fromStatus !== null;
+  const isBugFix = issueType.includes('bug') && isTicketCompletion;
+
   return {
     xp: xpAwarded,
     reason: reasons.join(', ') || 'No XP awarded',
+    tracking: {
+      isTicketCompletion: isTicketCompletion,
+      isBugFix: isBugFix
+    },
     breakdown: {
       baseXp: xpAwarded - (storyPoints * XP_RULES.STORY_POINTS_MULTIPLIER || 0) - 
               (issueType.includes('bug') && (toStatus === 'Done' || toStatus === 'Closed' || toStatus === 'Resolved') ? XP_RULES.BUG_BONUS : 0),


### PR DESCRIPTION
## Summary
• Implements automatic quest and bug tracking for the `/rpg-status` command
• Quest and bug counters now increment automatically when JIRA tickets are completed
• Uses atomic database updates to prevent race conditions

## Key Changes
• **Enhanced XP Calculator**: Added tracking metadata to detect ticket completions and bug fixes
• **Atomic Counter Updates**: Modified `awardXP` function to use Firestore `increment()` for thread-safe updates
• **Webhook Integration**: Updated webhook processing pipeline to pass tracking information through

## Logic Implementation
• **Total Quests**: All completed tickets (bugs + features + tasks + stories)
• **Bugs Slain**: Only completed bug issues (subset of total quests)
• **Completion Detection**: Status transitions to Done/Closed/Resolved with previous status different
• **Bug Detection**: Issue type contains "bug" (case-insensitive) AND ticket is completed

## Technical Details
• Uses Firestore `increment(1)` for atomic counter updates
• Single database operation updates XP, level, title, and counters together
• Backward compatible - existing functionality unchanged
• Comprehensive edge case handling (same status transitions, partial bug names, missing changelogs)

## Test Results
✅ Regular story completion: counts as quest, not bug  
✅ Bug fix completion: counts as both quest AND bug  
✅ In-progress work: gives XP, no completion counting  
✅ Edge cases: same status transitions, partial bug names, no changelogs

🤖 Generated with [Claude Code](https://claude.ai/code)