### PR TITLE
Fix DM conversation scope bug preventing epic tale responses

### DIFF
--- a/api/slack-events.js
+++ b/api/slack-events.js
@@ -132,7 +132,17 @@ async function handleDirectMessage(event) {
     console.log('Processing DM from user:', user, 'Text:', text.substring(0, 100));
 
     // Check if user is registered in our system
-    const userData = await getUserBySlackId(user);
+    let userData;
+    try {
+      console.log('Looking up user by Slack ID:', user);
+      userData = await getUserBySlackId(user);
+      console.log('User lookup result:', userData ? 'found' : 'not found');
+    } catch (error) {
+      console.error('Error during user lookup:', error);
+      await sendErrorMessage(channel);
+      return;
+    }
+    
     if (!userData) {
       console.log('User not registered:', user);
       await sendNotRegisteredMessage(channel);
@@ -140,7 +150,14 @@ async function handleDirectMessage(event) {
     }
 
     // Handle the conversational request
-    await handleConversationalRequest(user, text, channel, userData);
+    try {
+      console.log('Starting conversational request for user:', userData.jiraUsername);
+      await handleConversationalRequest(user, text, channel, userData);
+      console.log('Conversational request completed successfully');
+    } catch (error) {
+      console.error('Error in conversational request:', error);
+      await sendErrorMessage(channel);
+    }
 
   } catch (error) {
     console.error('Error handling direct message:', error);

--- a/lib/conversation-service.js
+++ b/lib/conversation-service.js
@@ -169,9 +169,10 @@ async function generateStoriesResponse(userMessage, stories) {
     
     // Always use Ollama to generate NEW conversational epic tales
     // (Saved stories are used for data, but we want fresh storytelling for conversations)
+    let simplifiedTickets;
     if (hasNarratives) {
       // Transform saved stories to ticket format for Ollama consumption
-      const simplifiedTickets = stories.map(story => ({
+      simplifiedTickets = stories.map(story => ({
         ticketKey: story.ticketKey,
         title: story.title || story.ticketData?.title || story.ticketData?.summary || 'Quest Completed',
         status: 'completed', // All saved stories are completed
@@ -186,7 +187,7 @@ async function generateStoriesResponse(userMessage, stories) {
       }));
     } else {
       // Fall back to generating new narratives from JIRA data
-      const simplifiedTickets = stories.map(story => ({
+      simplifiedTickets = stories.map(story => ({
         ticketKey: story.ticketKey,
         title: story.title,
         status: story.status,


### PR DESCRIPTION
## Summary
- Fixes JavaScript scope bug causing `ReferenceError: simplifiedTickets is not defined` in DM conversations
- Resolves issue where users wouldn't receive responses when asking about their JIRA work via DMs
- Adds enhanced error logging for better debugging of conversation flow issues

## Root Cause
The `simplifiedTickets` variable was declared inside `if/else` blocks but referenced outside their scope in `conversation-service.js:204`, causing a ReferenceError that prevented the Ollama API call from executing.

## Changes Made
- **lib/conversation-service.js**: Move `simplifiedTickets` variable declaration to proper scope
- **api/slack-events.js**: Add detailed error logging and try/catch blocks around user lookup and conversation handling

## Test Plan
- [x] Tested conversation flow with mock user data bypassing Firebase
- [x] Verified Ollama API integration works correctly  
- [x] Confirmed epic tale generation and Slack response delivery
- [x] Enhanced logging provides clear debugging information

## Impact
Users can now successfully receive epic tales of their JIRA accomplishments via DM conversations. The conversation system processes user intents, fetches saved stories, generates fresh narratives via Ollama, and delivers responses to Slack.

🤖 Generated with [Claude Code](https://claude.ai/code)