### PR TITLE
debug: add detailed logging to identify DM conversation failure point

### DIFF
--- a/api/slack-events.js
+++ b/api/slack-events.js
@@ -131,11 +131,12 @@ async function handleDirectMessage(event) {
 
     // Handle the conversational request
     try {
-      console.log('Starting conversational request for user:', userData.jiraUsername);
+      console.log('Starting conversational request for user:', userData.jiraUsername, 'message:', text.substring(0, 50));
       await handleConversationalRequest(user, text, channel, userData);
       console.log('Conversational request completed successfully');
     } catch (error) {
       console.error('Error in conversational request:', error);
+      console.error('Error stack:', error.stack);
       await sendErrorMessage(channel);
     }
 

--- a/lib/conversation-service.js
+++ b/lib/conversation-service.js
@@ -25,17 +25,21 @@ export async function handleConversationalRequest(userId, userMessage, channel, 
     let response;
 
     if (intent.needsTicketData) {
+      console.log('Intent requires ticket data, fetching stories...');
       // First try to get saved stories, then fall back to JIRA if needed
       const stories = await fetchRelevantStories(userData.jiraUsername, intent.filters);
       console.log(`Fetched ${stories.length} stories for storytelling`);
 
       if (stories.length === 0) {
+        console.log('No stories found, generating no-stories response');
         response = await generateNoStoriesResponse(userMessage, intent);
       } else {
+        console.log('Stories found, generating stories response with Ollama');
         response = await generateStoriesResponse(userMessage, stories);
       }
     } else {
       // General conversation - no ticket data needed
+      console.log('Intent is general conversation, not ticket-related');
       response = await generateGeneralResponse(userMessage);
     }
 


### PR DESCRIPTION
- Add step-by-step logging in conversation service flow
- Track intent parsing (needsTicketData vs general conversation)
- Log story fetching results and response path selection
- Add error stack traces for better debugging
- Log message preview in slack-events for context

This will help identify why production DM conversations aren't reaching the 'Calling conversational model' log message.